### PR TITLE
Migration from deprecated displayBuffer object

### DIFF
--- a/lib/remember-folds.js
+++ b/lib/remember-folds.js
@@ -34,12 +34,11 @@ export default {
   },
 
   onOpenTextEditor(editor) {
-    const foldsMarkerLayer = editor.buffer.displayLayers[0].foldsMarkerLayer;
     let uri = editor.getURI()
     let folds = this.folds[uri]
     if (folds && this.lineCounts[uri] === editor.getLineCount()) {
       for (let fold of folds) {
-        foldsMarkerLayer.markRange(fold);
+        editor.foldBufferRange(fold)
       }
     }
   },

--- a/lib/remember-folds.js
+++ b/lib/remember-folds.js
@@ -27,7 +27,7 @@ export default {
 
     this.subscriptions.add(atom.workspace.onDidDestroyPaneItem((event) => {
       let editor = event.item // maybe editor.
-      if (editor.displayBuffer) {
+      if (editor.buffer) {
         this.onCloseTextEditor(editor)
       }
     }))
@@ -44,12 +44,12 @@ export default {
   },
 
   onCloseTextEditor(editor) {
-    let foldsByMarkerId = editor.displayBuffer.foldsByMarkerId
+    let foldsByMarkerId = editor.buffer.displayLayers[0].foldsMarkerLayer.markersById
     let uri = editor.getURI()
     let folds = []
     for (let markerId in foldsByMarkerId) {
       let fold = foldsByMarkerId[markerId]
-      folds.push(fold.getBufferRowRange())
+      folds.push(fold.getRange())
     }
     this.folds[uri] = folds
     this.lineCounts[uri] = editor.getLineCount()

--- a/lib/remember-folds.js
+++ b/lib/remember-folds.js
@@ -34,17 +34,18 @@ export default {
   },
 
   onOpenTextEditor(editor) {
+    const foldsMarkerLayer = editor.buffer.displayLayers[0].foldsMarkerLayer;
     let uri = editor.getURI()
     let folds = this.folds[uri]
     if (folds && this.lineCounts[uri] === editor.getLineCount()) {
       for (let fold of folds) {
-        editor.foldBufferRow(fold[0])
+        foldsMarkerLayer.markRange(fold);
       }
     }
   },
 
   onCloseTextEditor(editor) {
-    let foldsByMarkerId = editor.buffer.displayLayers[0].foldsMarkerLayer.markersById
+    const foldsByMarkerId = editor.buffer.displayLayers[0].foldsMarkerLayer.markersById
     let uri = editor.getURI()
     let folds = []
     for (let markerId in foldsByMarkerId) {


### PR DESCRIPTION
Changes required to support Atom version 1.9.5 (and maybe prior releases).